### PR TITLE
Add comments and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,29 @@ This project transforms an Elegoo Smart Robot Car into a voice-controlled robot 
 4. Parsed via local LLaMA
 5. JSON command returned (e.g., `{"action": "turn_left", "duration": 2}`)
 
-## 🛠 Setup instructions and more coming soon.
+## 🛠 Setup
+
+1. Install the Python dependencies inside the `server/` folder:
+
+   ```bash
+   pip install -r server/requirements.txt
+   ```
+
+2. Start the FastAPI server:
+
+   ```bash
+   uvicorn server.main:app --reload
+   ```
+
+3. Send an audio file to the `/process-audio/` endpoint. A helper script
+   is provided:
+
+   ```bash
+   python server/test-upload.py
+   ```
+
+   The script posts the sample `forward.wav` recording and prints the
+   transcription along with the JSON command parsed by the LLaMA model.
+
+More detailed hardware instructions are tracked in `tasks.md`.
 

--- a/server/llama_interface.py
+++ b/server/llama_interface.py
@@ -1,15 +1,21 @@
+"""Interface for sending text to a LLaMA model and returning JSON commands."""
+
 import requests
 import json
 
 def parse_command(text):
+    """Return a JSON command parsed from plain text using a LLaMA model."""
     prompt = f"Convert this to JSON: {text}"
 
     try:
-        response = requests.post("http://localhost:11434/api/generate", json={
-            "model": "phi3:mini",  # or whichever model you're running
-            "prompt": prompt,
-            "stream": False
-        })
+        response = requests.post(
+            "http://localhost:11434/api/generate",
+            json={
+                "model": "phi3:mini",  # or whichever model you're running
+                "prompt": prompt,
+                "stream": False,
+            },
+        )
 
         result = response.json()
         raw_output = result.get("response", "")
@@ -19,7 +25,9 @@ def parse_command(text):
         json_end = raw_output.rfind("}") + 1
         json_block = raw_output[json_start:json_end]
 
+        # Convert the JSON string from the model into a Python object
         return json.loads(json_block)
 
     except Exception as e:
-        return { "error": f"Could not parse model response: {e}" }
+        # On any failure return an error dictionary instead of raising
+        return {"error": f"Could not parse model response: {e}"}

--- a/server/main.py
+++ b/server/main.py
@@ -1,3 +1,5 @@
+"""FastAPI server for transcribing audio and returning robot commands."""
+
 from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import JSONResponse
 from llama_interface import parse_command
@@ -6,15 +8,19 @@ import os
 
 app = FastAPI()
 
-# Load the Whisper model once when the server starts
+# Load the Whisper model once when the server starts. Adjust the model size
+# depending on the resources available on your machine.
 model = whisper.load_model("base")  # Options: tiny, base, small, medium, large
 
 @app.post("/process-audio/")
 async def process_audio(file: UploadFile = File(...)):
+    """Receive an audio file, transcribe it and return a JSON command."""
+    # Whisper expects a file on disk, so we write the uploaded data to a
+    # temporary WAV file.
     temp_path = "temp.wav"
 
     try:
-        # Save uploaded file temporarily
+        # Save the uploaded file temporarily so Whisper can access it
         with open(temp_path, "wb") as f:
             f.write(await file.read())
 
@@ -22,16 +28,17 @@ async def process_audio(file: UploadFile = File(...)):
         result = model.transcribe(temp_path)
         transcription = result["text"]
 
-        # Parse command from transcription
+        # Feed the transcription to the LLaMA model which returns a
+        # structured JSON command that the robot can interpret.
         command = parse_command(transcription)
 
-        # Clean up
+        # Remove the temporary file now that we're done with it
         os.remove(temp_path)
 
-        # Return transcription and parsed command
+        # Return both the raw transcription and the parsed command
         return {
             "transcription": transcription,
-            "command": command
+            "command": command,
         }
 
     except Exception as e:

--- a/server/test-upload.py
+++ b/server/test-upload.py
@@ -1,6 +1,12 @@
+"""Simple helper script to post a test audio file to the local server."""
+
 import requests
 
-audio_path = "../sample-audio/forward.wav"  # Adjust path as needed
+# Path to the WAV file we want to send. Feel free to swap this out with your
+# own recordings.
+audio_path = "../sample-audio/forward.wav"
+
+# Endpoint exposed by FastAPI in ``server/main.py``.
 url = "http://localhost:8000/process-audio/"
 
 with open(audio_path, "rb") as f:


### PR DESCRIPTION
## Summary
- document how to run the server in the README
- add docstrings and inline comments in `server/main.py`
- clarify LLaMA interface with comments and a module docstring
- explain the helper script in `test-upload.py`

## Testing
- `python -m py_compile server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684dc599c25c8324b95e318b578d7dfa